### PR TITLE
Event Page Update

### DIFF
--- a/src/mysite/code/objects/Event.php
+++ b/src/mysite/code/objects/Event.php
@@ -1,0 +1,61 @@
+<?php
+
+class Event extends DataObject
+{
+    static $db = array(
+        'SortOrder' => 'Int',
+        'Title' => 'Varchar(100)',
+        'Description' => 'Text',
+        'Date' => 'Date',
+        'Link' => 'Text',
+    );
+
+    static $default_sort = 'SortOrder';
+
+    static $has_one = array(
+        'Image' => 'Image',
+        'EventPage' => 'EventPage',
+    );
+
+    static $many_many = array(
+        'EventCategories' => 'EventCategory'
+    );
+
+    public function getCMSFields()
+    {
+
+        $fields = new FieldList(array(
+            UploadField::create('Image', 'Image(800x600)'),
+            TextField::create('Title', 'Title'),
+            TextareaField::create('Description', 'Description'),
+            DateField::create('Date', 'Date')->setConfig('showcalendar', true),
+            TextField::create('Link', 'Eventbrite Link'),
+            ListboxField::create('EventCategories', 'Categories', EventCategory::get()->map()->toArray())->setMultiple(true),
+        ));
+
+        return $fields;
+    }
+
+    public function summaryFields(){
+        return array(
+            'getThumbnail' => 'Image',
+            'Title' => 'Title',
+            'Description' => 'Description',
+            'Date' => 'Date',
+            'Link' => 'Link'
+        );
+    }
+
+    public function getThumbnail() {
+        return $this->Image()->Fit(120,120);
+    }
+
+    public function cat2class(){
+        $class = '';
+        foreach($this->EventCategories() as $item)   $class .= "$item->URLSegment ";
+
+        return $class;
+    }
+
+
+}

--- a/src/mysite/code/objects/EventCategory.php
+++ b/src/mysite/code/objects/EventCategory.php
@@ -1,0 +1,35 @@
+<?php
+
+class EventCategory extends DataObject
+{
+    static $db = array(
+        'SortOrder' => 'Int',
+        'Title' => 'Varchar(100)',
+        'URLSegment' => 'Varchar(100)'
+    );
+
+    static $default_sort = 'SortOrder';
+
+    static $belong_many_many = array(
+        'Events' => 'Event'
+    );
+
+    public function getCMSFields(){
+        return new FieldList(array(
+            TextField::create('Title', 'Title')
+        ));
+    }
+
+    public function summaryFields(){
+        return array(
+            'Title' => 'Title',
+        );
+    }
+
+    public function onBeforeWrite(){
+        if(isset($this->Title))
+            $this->URLSegment = SiteTree::singleton()->generateURLSegment($this->Title);
+
+        parent::onBeforeWrite();
+    }
+}

--- a/src/mysite/code/pages/EventPage.php
+++ b/src/mysite/code/pages/EventPage.php
@@ -1,23 +1,67 @@
 <?php
 
-class EventPage extends Page{
-    static $db = array(
-    );
+class EventPage extends Page
+{
+    static $db = array();
 
     static $allowed_children = array(
-        'EventGalleryPage','RedirectorPage'
+        'EventGalleryPage', 'RedirectorPage'
     );
 
-    public function getCMSFields(){
+    public function getCMSFields()
+    {
         $fields = parent::getCMSFields();
 
         return $fields;
     }
 }
 
-class EventPage_Controller extends Page_Controller{
+class EventPage_Controller extends Page_Controller
+{
 
-    public function getEventGalleryPages(){
+    public function getEventGalleryPages()
+    {
         return EventGalleryPage::get()->filter('ParentID', $this->ID);
+    }
+
+    public function getEventbriteEvents($location = null)
+    {
+        $fetch = new RestfulService(
+            'https://www.eventbriteapi.com/v3/events/search/'
+        );
+
+        $queryString = array(
+            'organizer.id' => '11613235556',
+            'token' => 'WJN73SMN37UUWDZKGUC3'
+        );
+
+        if (isset($location)) {
+            $queryString['location.address'] = $location;
+            $queryString['location.within'] = '20km';
+        }
+
+
+        $fetch->setQueryString($queryString);
+
+        // perform the query
+        $conn = $fetch->request();
+
+        print_r(json_decode($conn->getBody()));
+
+        // parse the XML body
+        $msgs = $fetch->getValues($conn->getBody(), "results");
+
+        // generate an object our templates can read
+        $output = new ArrayList();
+
+        if ($msgs) {
+            foreach ($msgs as $msg) {
+                $output->push(new ArrayData(array(
+                    'Description' => Convert::xml2raw($msg->channel_item_description)
+                )));
+            }
+        }
+
+        return $output;
     }
 }

--- a/src/mysite/code/pages/HomePage.php
+++ b/src/mysite/code/pages/HomePage.php
@@ -6,12 +6,12 @@ class HomePage extends Page {
         //Top Content
         'TopTitle' => 'Varchar(100)',
         'TopDescription' => 'HTMLText',
-        'TopEventTitle' => 'Varchar(100)',
-        'TopEventDescription' => 'Text',
         'TopLabTitle' => 'Varchar(100)',
         'TopLabDescription' => 'Text',
         'TopWorkTitle' => 'Varchar(100)',
         'TopWorkDescription' => 'Text',
+        'TopInstituteTitle' => 'Varchar(100)',
+        'TopInstituteDescription' => 'Text',
 
         //Block1 Content
         'Block1Title' => 'Varchar(100)',
@@ -20,20 +20,23 @@ class HomePage extends Page {
         //Block2 Content
         'Block2TopTitle' => 'Varchar(100)',
         'Block2TopContent' => 'HTMLText',
+        'Block2MiddleTitle' => 'Varchar(100)',
+        'Block2MiddleContent' => 'HTMLText',
         'Block2BottomTitle' => 'Varchar(100)',
         'Block2BottomContent' => 'HTMLText',
 
-        //block3 qoute
+        //block3 quote
         'Block3Title' => 'Varchar(100)',
     );
 
     static $has_one = array(
         'Block2TopImage' => 'Image',
+        'Block2MiddleImage' => 'Image',
         'Block2BottomImage' => 'Image',
         'TopBackground' => 'Image',
-        'EventsLinkedPage' => 'SiteTree',
         'LabsLinkedPage' => 'SiteTree',
         'WorkLinkedPage' => 'SiteTree',
+        'InstituteLinkedPage' => 'SiteTree',
     );
 
     function getCMSFields() {
@@ -52,19 +55,19 @@ class HomePage extends Page {
             new UploadField('TopBackground', 'Background (1920x900)'),
 
             new HeaderField('Labs'),
-            new TextField('TopEventTitle', 'Title'),
-            TreeDropdownField::create('EventsLinkedPageID', 'Link to page', 'SiteTree', 'ID', 'MenuTitle'),
-            new TextareaField('TopEventDescription', 'Description'),
-
-            new HeaderField('Work'),
             new TextField('TopLabTitle', 'Title'),
             TreeDropdownField::create('LabsLinkedPageID', 'Link to page', 'SiteTree', 'ID', 'MenuTitle'),
             new TextareaField('TopLabDescription', 'Description'),
 
-            new HeaderField('Institute'),
+            new HeaderField('Work'),
             new TextField('TopWorkTitle', 'Title'),
             TreeDropdownField::create('WorkLinkedPageID', 'Link to page', 'SiteTree', 'ID', 'MenuTitle'),
-            new TextareaField('TopWorkDescription', 'Description')
+            new TextareaField('TopWorkDescription', 'Description'),
+
+            new HeaderField('Institute'),
+            new TextField('TopInstituteTitle', 'Title'),
+            TreeDropdownField::create('InstituteLinkedPageID', 'Link to page', 'SiteTree', 'ID', 'MenuTitle'),
+            new TextareaField('TopInstituteDescription', 'Description')
         ));
         /*End Top*/
 
@@ -81,6 +84,11 @@ class HomePage extends Page {
             new UploadField('Block2TopImage', 'Image (1000x800)'),
             new TextField('Block2TopTitle', 'Title'),
             HtmlEditorField::create('Block2TopContent', 'Description')->setRows(10),
+
+            new HeaderField('Middle'),
+            new UploadField('Block2MiddleImage', 'Image (1000x800)'),
+            new TextField('Block2MiddleTitle', 'Title'),
+            HtmlEditorField::create('Block2MiddleContent', 'Description')->setRows(10),
 
             new HeaderField('Bottom'),
             new UploadField('Block2BottomImage', 'Image (1000x800)'),

--- a/src/mysite/code/pages/JobPage.php
+++ b/src/mysite/code/pages/JobPage.php
@@ -10,6 +10,7 @@ class JobPage extends Page
         'Company' => 'Varchar',
         'Location' => 'Text',
         'Requirements' => 'HTMLText',
+        'Contact' => 'Varchar'
     );
 
     public function getCMSFields()
@@ -18,16 +19,20 @@ class JobPage extends Page
         $fields->replaceField('Title', TextField::create('Title', 'Job Title'));
         $fields->removeByName('Content');
         $fields->removeByName('Banner');
-        $fields->addFieldToTab('Root.Main', TextField::create('Company', 'Company Name')->setMaxLength(50), 'Description');
-        $fields->addFieldToTab('Root.Main', TextField::create('Location', 'Job Location')->setMaxLength(50), 'Description');
-        $fields->addFieldToTab('Root.Main', DateField::create('Date', 'Deadline')->setConfig('showcalendar',true), 'Description');
-        $fields->addFieldToTab('Root.Main', TextareaField::create('Teaser', 'Quick Summary of the Job'), 'Description');
-        $fields->addFieldToTab('Root.Main', HTMLEditorField::create('Requirements', 'Job Requirements')->setRows(10), 'Description');
+        $fields->addFieldsToTab('Root.Main', array(
+            TextField::create('Company', 'Company Name')->setMaxLength(50),
+            TextField::create('Location', 'Job Location')->setMaxLength(50),
+            DateField::create('Date', 'Deadline')->setConfig('showcalendar', true),
+            TextareaField::create('Teaser', 'Quick Summary of the Job'),
+            HTMLEditorField::create('Requirements', 'Job Requirements')->setRows(10),
+            TextField::create('Contact', 'Email address where applications can be sent')), 'Description');
+
 
         return $fields;
     }
 }
 
-class JobPage_Controller extends Page_Controller{
+class JobPage_Controller extends Page_Controller
+{
 
 }

--- a/src/themes/simple/css/custom.css
+++ b/src/themes/simple/css/custom.css
@@ -74,6 +74,11 @@ ol li {
 	color: #494c52;
 }
 
+.g-recaptcha {
+	display: inline-block;
+	vertical-align: middle;
+}
+
 .btn-default.disabled, .btn-default[disabled], .btn-default {
 	border-color: #fc4513;
 	color: #fc4513;

--- a/src/themes/simple/templates/Includes/Header.ss
+++ b/src/themes/simple/templates/Includes/Header.ss
@@ -27,7 +27,6 @@
                         <li><a href="$Link">$MenuTitle</a></li>
                     <% end_if %>
                 <% end_loop %>
-                <li><a href="$AbsoluteLink#contact">Contact</a></li>
                 <li><span><a href="$AbsoluteLink#movement" class="btn btn-light btn-sm">Join the Movement</a></span></li>
             </ul>
 
@@ -59,25 +58,9 @@
                     <!-- flex-column -->
                     <div class="flex-col-md-4">
                         <!-- info-box -->
-                        <a href="$EventsLinkedPage.Link">
-                        <div class="info-box info-box7">
-                            <div class="img"><i class="icon-beaker"></i></div>
-                            <div class="info">
-                                <h2 class="hd">$TopEventTitle</h2>
-                                <p class="sub-txt">$TopEventDescription</p>
-                            </div>
-                        </div>
-                        </a>
-                        <!-- /.info-box -->
-                    </div>
-                    <!-- /.flex-column -->
-
-                    <!-- flex-column -->
-                    <div class="flex-col-md-4">
-                        <!-- info-box -->
                         <a href="$LabsLinkedPage.Link">
                         <div class="info-box info-box7">
-                            <div class="img"><i class="icon-briefcase"></i></div>
+                            <div class="img"><i class="icon-beaker"></i></div>
                             <div class="info">
                                 <h2 class="hd">$TopLabTitle</h2>
                                 <p class="sub-txt">$TopLabDescription</p>
@@ -93,11 +76,27 @@
                         <!-- info-box -->
                         <a href="$WorkLinkedPage.Link">
                         <div class="info-box info-box7">
-                            <div class="img"><i class="icon-lightbulb"></i></div>
+                            <div class="img"><i class="icon-briefcase"></i></div>
                             <div class="info">
                                 <h2 class="hd">$TopWorkTitle</h2>
-
                                 <p class="sub-txt">$TopWorkDescription</p>
+                            </div>
+                        </div>
+                        </a>
+                        <!-- /.info-box -->
+                    </div>
+                    <!-- /.flex-column -->
+
+                    <!-- flex-column -->
+                    <div class="flex-col-md-4">
+                        <!-- info-box -->
+                        <a href="$InstituteLinkedPage.Link">
+                        <div class="info-box info-box7">
+                            <div class="img"><i class="icon-lightbulb"></i></div>
+                            <div class="info">
+                                <h2 class="hd">$TopInstituteTitle</h2>
+
+                                <p class="sub-txt">$TopInstituteDescription</p>
                             </div>
                         </div>
                         </a>

--- a/src/themes/simple/templates/Layout/BlogEntryPage.ss
+++ b/src/themes/simple/templates/Layout/BlogEntryPage.ss
@@ -29,8 +29,8 @@
                 <hr class="mr-t-10 mr-b-30 bdr-dark1">
                 <h3 class="hd-3">Keep Reading</h3>
                 <div class="gt40">
-                    <div class="col-md-5" style="height: 253px;">
-                        <% if $PrevNextPage('prev') %>
+                    <% if $PrevNextPage('prev') && $PrevNextPage('prev').Active %>
+                        <div class="col-md-5">
                             <a href="$PrevNextPage('prev').Link">
                                 <div class="info-box info-box7">
                                     <img src="$PrevNextPage('prev').Thumbnail.URL" class="img-responsive blog-thumbs" alt="Image">
@@ -42,12 +42,10 @@
                                     </div>
                                 </div>
                             </a>
-                        <% else %>
-
-                        <% end_if %>
-                    </div>
-                    <div class="col-md-5">
-                        <% if $PrevNextPage('next') %>
+                        </div>
+                    <% end_if %>
+                    <% if $PrevNextPage('next') && $PrevNextPage('next').Active %>
+                        <div class="col-md-5">
                             <a href="$PrevNextPage('next').Link">
                                 <div class="info-box info-box7">
                                     <img src="$PrevNextPage('next').Thumbnail.URL" class="img-responsive blog-thumbs" alt="Image">
@@ -59,10 +57,8 @@
                                     </div>
                                 </div>
                             </a>
-                        <% else %>
-
-                        <% end_if %>
-                    </div>
+                        </div>
+                    <% end_if %>
                 </div>
             <% end_if %>
             <div class="col-md-12">

--- a/src/themes/simple/templates/Layout/EventPage.ss
+++ b/src/themes/simple/templates/Layout/EventPage.ss
@@ -1,3 +1,39 @@
+<section class="content-section align-c content-section-9" id="upcoming">
+    <div class="container z1">
+        <h2 class="title $SubTitleColor">$Title</h2>
+        <div class="container filter-widget filter-style1 filterwidget1" id="filterwidget1" style="opacity: 1;">
+            <div class="filter-list">
+                <a class="active" data-filter="*">All</a>
+                <% loop $getEventCategories %>
+                    <a data-filter=".$URLSegment">$Title</a>
+                <% end_loop %>
+            </div>
+        </div>
+        <!-- /filter widget -->
+
+        <div class="row eqh gt40 fs-equalize-element grid">
+            <% loop $Events %>
+                <div class="col-md-4 col-sm-6 element-item $cat2class" style="min-height: 488px;">
+                    <div class="info-box info-box8">
+                        <div class="img"><a href="$Link" target="_blank"><img src="$Image.URL"
+                                                                              class="img-responsive"
+                                                                              alt="Shaping a Digital World"></a>
+                        </div>
+                        <div class="info">
+                            <h3 class="hd-3"><a href="$Link" target="_blank">$Title</a></h3>
+                            <h4 class="hd">$Date.Long</h4>
+                            <p class="sub-txt">$Description</p>
+                            <a href="$Link" target="_blank" class="btn btn-default btn-xs ">More info <i
+                                    class="fa fa-external-link" aria-hidden="true"></i></a>
+                        </div>
+                    </div>
+                </div>
+            <% end_loop %>
+        </div>
+    </div>
+    <!-- /.container -->
+</section>
+
 <!-- content-section -->
 <section class="content-section content-section-common $topClass" id="{$URLSegment}">
     <div class="container about-content">
@@ -13,12 +49,10 @@
             </div>
         </div>
     </div>
-
-    <div>
-        <%--$getEventbriteEvents()--%>
-    </div>
     <!-- /container -->
 </section><!-- /content-section -->
+
+
 
 <% if $getEventGalleryPages %>
     <section class="content-section align-c content-section-9">

--- a/src/themes/simple/templates/Layout/EventPage.ss
+++ b/src/themes/simple/templates/Layout/EventPage.ss
@@ -13,6 +13,10 @@
             </div>
         </div>
     </div>
+
+    <div>
+        <%--$getEventbriteEvents()--%>
+    </div>
     <!-- /container -->
 </section><!-- /content-section -->
 

--- a/src/themes/simple/templates/Layout/EventPage.ss
+++ b/src/themes/simple/templates/Layout/EventPage.ss
@@ -1,4 +1,4 @@
-<section class="content-section align-c content-section-9" id="upcoming">
+<section class="content-section align-c content-section-9" id="{$URLSegment}">
     <div class="container z1">
         <h2 class="title $SubTitleColor">$Title</h2>
         <div class="container filter-widget filter-style1 filterwidget1" id="filterwidget1" style="opacity: 1;">
@@ -35,7 +35,7 @@
 </section>
 
 <!-- content-section -->
-<section class="content-section content-section-common $topClass" id="{$URLSegment}">
+<section class="content-section content-section-common $topClass">
     <div class="container about-content">
         <div class="flex-col-md-8 flex-col-md-offset-2">
             <% if $Description %>

--- a/src/themes/simple/templates/Layout/HomePage.ss
+++ b/src/themes/simple/templates/Layout/HomePage.ss
@@ -34,14 +34,35 @@
 
 <section class="content-section content-section-11">
 
-    <!-- <div class="full-wh bg-section bg-cover w-50" data-bg="images/bg-img6.jpg"></div> -->
+    <!-- <div class="full-wh bg-section bg-cover w-50" data-bg="images/bg.jpg"></div> -->
 
     <div class="container-fluid">
 
         <div class="row eqh fs-equalize-element">
-            <div class="col-md-6 l bg-cover bg-cc" data-bg="{$Block2BottomImage.URL}" style="background-image: url(&quot;{$Block2BottomImage.URL}&quot;); height: 651px;"></div>
+            <div class="col-md-6 l bg-cover bg-cc" data-bg="{$Block2MiddleImage.URL}" style="background-image: url(&quot;{$Block2BottomImage.URL}&quot;); height: 651px;"></div>
 
             <div class="col-md-6 r" style="height: 651px;">
+                <div class="content">
+                    <h2 class="title">$Block2MiddleTitle</h2>
+                    <div class="title-sub mr-b-40">$Block2MiddleContent</div>
+                </div><!-- /.content -->
+            </div><!-- /.col-lg-5 -->
+
+        </div><!-- /.row -->
+
+    </div><!-- /.container -->
+</section><!-- /.content-section -->
+
+<section class="content-section content-section-11">
+
+    <!-- <div class="full-wh bg-section bg-cover w-50" data-bg="images/bg.jpg"></div> -->
+
+    <div class="container-fluid">
+
+        <div class="row eqh fs-equalize-element">
+            <div class="col-md-6 l col-md-push-6 bg-cover bg-cc" data-bg="{$Block2BottomImage.URL}" style="background-image: url(&quot;{$Block2BottomImage.URL}&quot;); height: 651px;"></div>
+
+            <div class="col-md-6 col-md-pull-6 r" style="height: 651px;">
                 <div class="content">
                     <h2 class="title">$Block2BottomTitle</h2>
                     <div class="title-sub mr-b-40">$Block2BottomContent</div>
@@ -51,7 +72,9 @@
         </div><!-- /.row -->
 
     </div><!-- /.container -->
-</section><!-- /.content-section --><!-- Testimonials -->
+</section><!-- /.content-section -->
+
+<!-- Testimonials -->
 
 <section class="testimonial-section dark testimonial-section-3">
     <div class="container-fluid">

--- a/src/themes/simple/templates/Layout/JobPage.ss
+++ b/src/themes/simple/templates/Layout/JobPage.ss
@@ -15,6 +15,17 @@
                     <hr class="mr-b-10">
                     <h4 class="hd-4">Deadline To Apply</h4>
                     <p>$Date.Long</p>
+                    <hr class="mr-b-10">
+                    <h4 class="hd-4">Application</h4>
+                    <p>
+                        Please submit Cover Letter and Resume to
+                        <% if $Contact %>
+                            <a href="mailto:{$Contact}?subject={$Title}%20-%20{$Company}">$Contact</a>
+                        <% else %>
+                            <a href="mailto:jobs@faithtech.com?subject={$Title}%20-%20{$Company}">jobs@faithtech.com</a>
+                        <% end_if %>
+                        with <b>$Title - $Company</b> in the subject line
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This update to the site primarily includes the addition of a "current events" section which allows FaithTech events to be added to the event page and linked to Eventbrite (see http://dev.faithtech.com/about/events). Secondly, it includes a change to the "Keep Reading" section on the `BlogEntryPage` that prevents posts from being shown if they aren't active (see http://dev.faithtech.com/institute/one-more-test - the post "Andrew is testing" is not visible). It also includes a change to the `HomePage` - adding a 3rd block to the content section (see http://dev.faithtech.com/). Minor updates include adding contact info to the Job Board, a Captcha bug fix, and updating `Header` and `HomePage` to avoid `DataObject` mismatches.

Work done:
- updated `JobPage` to include contact info
- updated `HomePage` and `Header` to avoid `DataObject` mismatches
- captcha bug fix in `custom.css`
- added event listing on `EventPage`, modelling after `ResourcesPage`
- added condition on `BlogEntryPage` to not show posts with the `Active` property set to `False` in "Keep Reading" section
